### PR TITLE
Enforcing tab height to 26px

### DIFF
--- a/whitefox/browser/browser-common.css
+++ b/whitefox/browser/browser-common.css
@@ -2253,6 +2253,7 @@ toolbarbutton[type="socialmark"] > .toolbarbutton-icon {
 
 #tabbrowser-tabs {
   margin: 0 3px;
+  height: 28px; /*Enforcing tab height so addons that add icons on tabs don't break them (see https://github.com/louischan/simplewhite/issues/34) *//*SW1FT*/
 }
 
 .tabbrowser-tab:not([pinned]) {

--- a/whitefox/browser/browser-common.css
+++ b/whitefox/browser/browser-common.css
@@ -2253,7 +2253,7 @@ toolbarbutton[type="socialmark"] > .toolbarbutton-icon {
 
 #tabbrowser-tabs {
   margin: 0 3px;
-  height: 28px; /*Enforcing tab height so addons that add icons on tabs don't break them (see https://github.com/louischan/simplewhite/issues/34) *//*SW1FT*/
+  height: 26px; /*Enforcing tab height so addons that add icons on tabs don't break them (see https://github.com/louischan/simplewhite/issues/34) *//*SW1FT*/
 }
 
 .tabbrowser-tab:not([pinned]) {


### PR DESCRIPTION
Enforcing tab height so addons that add icons on tabs don't break them (see https://github.com/louischan/simplewhite/issues/34). For the average user this will not change anything, but for someone that uses Noise Control (for example), this will fix the unintentional behavior of the tabs.

EDIT: It's not 28px, it's actually 26px, sorry for the confusion.
